### PR TITLE
Private domains fix permissions

### DIFF
--- a/api/application/services/authorisation_service.py
+++ b/api/application/services/authorisation_service.py
@@ -207,12 +207,10 @@ def _get_acceptable_sensitivity_values(dataset: str, domain: str) -> List[str]:
         implied_sensitivity_map = {
             # The levels in the values imply the levels in the key
             SensitivityLevel.PUBLIC: [
-                SensitivityLevel.SENSITIVE,
                 SensitivityLevel.PRIVATE,
                 SensitivityLevel.PUBLIC,
             ],
             SensitivityLevel.PRIVATE: [
-                SensitivityLevel.SENSITIVE,
                 SensitivityLevel.PRIVATE,
             ],
         }

--- a/api/common/config/auth.py
+++ b/api/common/config/auth.py
@@ -52,7 +52,6 @@ def construct_user_auth_url(client_id: str):
 class Action(BaseEnum):
     READ = "READ"
     WRITE = "WRITE"
-    DELETE = "DELETE"
     ADD_CLIENT = "ADD_CLIENT"
     ADD_SCHEMA = "ADD_SCHEMA"
 

--- a/api/common/config/auth.py
+++ b/api/common/config/auth.py
@@ -52,12 +52,12 @@ def construct_user_auth_url(client_id: str):
 class Action(BaseEnum):
     READ = "READ"
     WRITE = "WRITE"
-    ADD_CLIENT = "ADD_CLIENT"
-    ADD_SCHEMA = "ADD_SCHEMA"
+    USER_ADMIN = "USER_ADMIN"
+    DATA_ADMIN = "DATA_ADMIN"
 
     @staticmethod
     def standalone_actions() -> List:
-        return [Action.ADD_CLIENT, Action.ADD_SCHEMA]
+        return [Action.USER_ADMIN, Action.DATA_ADMIN]
 
 
 # Classifications
@@ -65,5 +65,4 @@ class Action(BaseEnum):
 class SensitivityLevel(BaseEnum):
     PUBLIC = "PUBLIC"
     PRIVATE = "PRIVATE"
-    SENSITIVE = "SENSITIVE"
     PROTECTED = "PROTECTED"

--- a/api/controller/client.py
+++ b/api/controller/client.py
@@ -19,7 +19,7 @@ client_router = APIRouter(
 @client_router.post(
     "",
     status_code=http_status.HTTP_201_CREATED,
-    dependencies=[Security(protect_endpoint, scopes=[Action.ADD_CLIENT.value])],
+    dependencies=[Security(protect_endpoint, scopes=[Action.USER_ADMIN.value])],
 )
 async def create_client(client_request: ClientRequest):
     client_response = client_service.create_client(client_request)

--- a/api/controller/datasets.py
+++ b/api/controller/datasets.py
@@ -75,7 +75,7 @@ async def list_raw_files(domain: str, dataset: str):
 
 @datasets_router.delete(
     "/{domain}/{dataset}/{filename}",
-    dependencies=[Security(protect_dataset_endpoint, scopes=[Action.DELETE.value])],
+    dependencies=[Security(protect_dataset_endpoint, scopes=[Action.WRITE.value])],
 )
 async def delete_data_file(
     domain: str, dataset: str, filename: str, response: Response

--- a/api/controller/protected_domain.py
+++ b/api/controller/protected_domain.py
@@ -20,8 +20,7 @@ protected_domain_router = APIRouter(
 @protected_domain_router.post(
     "/{domain}",
     status_code=http_status.HTTP_201_CREATED,
-    # TODO: Make the action a DATA_ADMIN one rather than just ADD_SCHEMA
-    dependencies=[Security(protect_endpoint, scopes=[Action.ADD_SCHEMA.value])],
+    dependencies=[Security(protect_endpoint, scopes=[Action.DATA_ADMIN.value])],
 )
 async def create_protected_domain(domain: str):
     await protected_domain_service.create_scopes(domain)

--- a/api/controller/schema.py
+++ b/api/controller/schema.py
@@ -47,7 +47,7 @@ async def generate_schema(
 @schema_router.post(
     "",
     status_code=http_status.HTTP_201_CREATED,
-    dependencies=[Security(protect_endpoint, scopes=[Action.ADD_SCHEMA.value])],
+    dependencies=[Security(protect_endpoint, scopes=[Action.DATA_ADMIN.value])],
 )
 async def upload_schema(schema: Schema):
     try:

--- a/docs/architecture/adr/0004-dataset-sensitivity.md
+++ b/docs/architecture/adr/0004-dataset-sensitivity.md
@@ -6,7 +6,7 @@ Accepted
 
 ## Context
 
-Datasets have an associated sensitivity level. Current values are one of `PUBLIC`, `PRIVATE` or `SENSITIVE`.
+Datasets have an associated sensitivity level. Current values are one of `PUBLIC`, `PRIVATE` or `PROTECTED`.
 
 We needed a mechanism for tying the sensitivity level to the dataset.
 

--- a/docs/guides/contributing/contributing.md
+++ b/docs/guides/contributing/contributing.md
@@ -245,8 +245,8 @@ action scopes:
 
 - `READ`
 - `WRITE`
-- `ADD_SCHEMA`
-- `ADD_CLIENT`
+- `DATA_ADMIN`
+- `USER_ADMIN`
 
 For instance, if `WRITE` scope is used, that means that whoever is trying to access the endpoint needs to have any
 of `WRITE_ALL`, `WRITE_<sensitivity_level>`, `WRITE/<domain>/<dataset>` scopes listed in their permissions or be part of

--- a/docs/guides/contributing/dev-usage.md
+++ b/docs/guides/contributing/dev-usage.md
@@ -47,7 +47,7 @@ extend this in the future.
 | Flow       | Token        | Auth method | Permission example                                 | Notes                                                             |
 |------------|--------------|-------------|----------------------------------------------------|-------------------------------------------------------------------|
 | User       | User Token   | User groups | `WRITE/domain1/dataset1`, `WRITE/domain2/dataset1` | No specificity at the sensitivity level, only domain and dataset  |
-| Client app | Client Token | Scopes      | `WRITE_PUBLIC`, `READ_SENSITIVE`                   | No specificity at the domain or dataset level, only sensitivity   |
+| Client app | Client Token | Scopes      | `WRITE_PUBLIC`, `READ_PRIVATE`                   | No specificity at the domain or dataset level, only sensitivity   |
 
 The "action" component of a permission (`READ`, `WRITE`, etc.) is used only in the matching logic when a request is made
 and compared to the specified scope assigned to the endpoint being accessed.

--- a/docs/guides/contributing/improvements.md
+++ b/docs/guides/contributing/improvements.md
@@ -145,41 +145,6 @@ infrastructure which does not have the latest security patches or bug fixes.
 
 Some mechanism for alerting departments of the need to update should also be implemented
 
-## How to change the data-file deletion endpoint from DELETE to WRITE permission
-
-### Context
-
-Upon implementation of the dataset deletion endpoint it was decided that a new permission scope would be introduced,
-namely `DELETE`, beyond the existing `READ` and `WRITE`.
-
-It is, however, anticipated that this endpoint may be folded into the `WRITE` permission and the `DELETE` permission
-deprecated in this instance.
-
-### Solution
-
-It is relatively straightforward to switch to using just the `WRITE` permission.
-
-Simply change the `DELETE` scope to `WRITE` in the endpoint dependencies:
-
-```
-OLD
-... scopes=[Action.DELETE.value])
-
-NEW
-... scopes=[Action.WRITE.value])
-```
-
-If the DELETE scope is now not being used elsewhere it may need to be deleted: remove references to it in the code and
-remove the scope from the Terraform (see "Adding/Deleting scopes for client apps" in
-the [documentation](application_context.md)).
-
-### Considerations & Assumptions
-
-- A user can only be assigned to maximum 100 groups in Cognito, so it makes sense to reduce the total number of action
-  scopes.
-- By using the `WRITE` action instead, there is an implication that write implies read and granular, layered permissions
-  are no longer possible.
-
 ## Change storage data format
 
 ### Problem

--- a/docs/guides/usage/schema_creation.md
+++ b/docs/guides/usage/schema_creation.md
@@ -20,8 +20,9 @@ The schema will have the following structure:
   - `partition_index` (Optional) - Integer value, whether the column is a [partition](#partitions-) and its index.
   - `format` (Conditional) - String value, regular expression used to specify the format of the dates. Will only be used and required if the data_type is date.
 
+# TODO: Add docs on protected
 ### Sensitivity 😭
-The sensitivity level of a dataset can be described by one of three values: `PUBLIC`, `PRIVATE` and `SENSITIVE`.
+The sensitivity level of a dataset can be described by one of three values: `PUBLIC`, `PRIVATE` and `PROTECTED`.
 These determine the access level that different clients will have to the data depending on their permissions.
 
 ### Tags 🏷

--- a/docs/guides/usage/usage.md
+++ b/docs/guides/usage/usage.md
@@ -565,7 +565,7 @@ When a valid file in the domain/dataset is deleted success message will be displ
 ### Accepted scopes
 
 You will always be able to get info on all available datasets, regardless of their sensitivity level, provided you have
-a `DELETE` scope, e.g.: `DELETE_ALL`, `DELETE_PUBLIC`, `DELETE_SENSITIVE`
+a `WRITE` scope, e.g.: `WRITE_ALL`, `WRITE_PUBLIC`, `WRITE_SENSITIVE`
 
 ### Examples
 

--- a/docs/guides/usage/usage.md
+++ b/docs/guides/usage/usage.md
@@ -24,7 +24,7 @@ During upload, a data 'crawler' is started which looks at the persisted data and
 has finished running (usually around 4-5 minutes) the data can be queried.
 
 The application can be used by both human and programmatic clients (see more below)
-- When accessing the REST API as a client application, different actions require the client to have different permissions e.g.:`READ`, `WRITE`, `ADD_SCHEMA`, etc., and different dataset sensitivity level permissions e.g.: `PUBLIC`, `PRIVATE`, etc.
+- When accessing the REST API as a client application, different actions require the client to have different permissions e.g.:`READ`, `WRITE`, `DATA_ADMIN`, etc., and different dataset sensitivity level permissions e.g.: `PUBLIC`, `PRIVATE`, etc.
 - When accessing the UI as a human user, permissions are granted by user groups e.g.: `WRITE/trains/completed_journeys`
 
 ## Data upload and query flows
@@ -106,7 +106,7 @@ output of this endpoint in the Schema Upload endpoint.
 
 | Parameters    | Usage                                   | Example values               | Definition            |
 |---------------|-----------------------------------------|------------------------------|-----------------------|
-| `sensitivity` | URL parameter                           | `PUBLIC, PRIVATE, SENSITIVE` | sensitivity of the dataset |
+| `sensitivity` | URL parameter                           | `PUBLIC, PRIVATE, PROTECTED` | sensitivity of the dataset |
 | `domain`      | URL parameter                           | `land`                       | domain of the dataset |
 | `dataset`     | URL parameter                           | `train_journeys`             | dataset title         |
 | `file`        | File in form data with key value `file` | `train_journeys.csv`         | the dataset file itself |
@@ -223,7 +223,7 @@ None
 
 ### Accepted scopes
 
-In order to use this endpoint you need the `ADD_SCHEMA` scope.
+In order to use this endpoint you need the `DATA_ADMIN` scope.
 
 ## Upload dataset
 
@@ -785,8 +785,8 @@ Available choices are:
 - `WRITE_PUBLIC` - allow client to write any public dataset
 - `WRITE_PRIVATE` - allow client to write any dataset with sensitivity private and below
 - `WRITE_SENSITIVE` - allow client to write any dataset with sensitivity sensitive and below
-- `ADD_SCHEMA` - allow client to add a schema for a dataset of any sensitivity
-- `ADD_CLIENT` - allow client to add a new client
+- `DATA_ADMIN` - allow client to add a schema for a dataset of any sensitivity
+- `USER_ADMIN` - allow client to add a new client
 
 ### Outputs
 
@@ -806,7 +806,7 @@ Once the new client has been created, the following information is returned in t
 
 ### Accepted scopes
 
-In order to use this endpoint you need the `ADD_CLIENT` scope
+In order to use this endpoint you need the `USER_ADMIN` scope
 
 # UI usage
 

--- a/docs/guides/usage/usage.md
+++ b/docs/guides/usage/usage.md
@@ -256,7 +256,7 @@ If successful returns file name with a timestamp included, e.g.:
 ### Accepted scopes
 
 In order to use this endpoint you need a relevant `WRITE` scope that matches the dataset sensitivity level,
-e.g.: `WRITE_ALL`, `WRITE_PUBLIC`, `WRITE_SENSITIVE`
+e.g.: `WRITE_ALL`, `WRITE_PUBLIC`, `WRITE_PRIVATE`
 
 ### Examples
 
@@ -356,7 +356,7 @@ If no dataset exists or none that matches the query, you will get an empty respo
 ### Accepted scopes
 
 You will always be able to list all available datasets, regardless of their sensitivity level, provided you have
-a `READ` scope, e.g.: `READ_ALL`, `READ_PUBLIC`, `READ_SENSITIVE`
+a `READ` scope, e.g.: `READ_ALL`, `READ_PUBLIC`, `READ_PRIVATE`
 
 ### Examples
 
@@ -494,7 +494,7 @@ Schema in json format in the response body:
 ### Accepted scopes
 
 You will always be able to get info on all available datasets, regardless of their sensitivity level, provided you have
-a `READ` scope, e.g.: `READ_ALL`, `READ_PUBLIC`, `READ_SENSITIVE`
+a `READ` scope, e.g.: `READ_ALL`, `READ_PUBLIC`, `READ_PRIVATE`
 
 ### Examples
 
@@ -534,7 +534,7 @@ List of raw files in json format in the response body:
 ### Accepted scopes
 
 You will always be able to get info on all available datasets, regardless of their sensitivity level, provided you have
-a `READ` scope, e.g.: `READ_ALL`, `READ_PUBLIC`, `READ_SENSITIVE`
+a `READ` scope, e.g.: `READ_ALL`, `READ_PUBLIC`, `READ_PRIVATE`
 
 ### Examples
 
@@ -565,7 +565,7 @@ When a valid file in the domain/dataset is deleted success message will be displ
 ### Accepted scopes
 
 You will always be able to get info on all available datasets, regardless of their sensitivity level, provided you have
-a `WRITE` scope, e.g.: `WRITE_ALL`, `WRITE_PUBLIC`, `WRITE_SENSITIVE`
+a `WRITE` scope, e.g.: `WRITE_ALL`, `WRITE_PUBLIC`, `WRITE_PUBLIC`
 
 ### Examples
 
@@ -780,11 +780,9 @@ Available choices are:
 - `READ_ALL` - allow client to read any dataset
 - `READ_PUBLIC` - allow client to read any public dataset
 - `READ_PRIVATE` - allow client to read any dataset with sensitivity private and below
-- `READ_SENSITIVE` - allow client to read any dataset with sensitivity sensitive and below
 - `WRITE_ALL` - allow client to write any dataset
 - `WRITE_PUBLIC` - allow client to write any public dataset
 - `WRITE_PRIVATE` - allow client to write any dataset with sensitivity private and below
-- `WRITE_SENSITIVE` - allow client to write any dataset with sensitivity sensitive and below
 - `DATA_ADMIN` - allow client to add a schema for a dataset of any sensitivity
 - `USER_ADMIN` - allow client to add a new client
 

--- a/test/api/adapter/test_s3_adapter.py
+++ b/test/api/adapter/test_s3_adapter.py
@@ -387,7 +387,7 @@ class TestDatasetMetadataRetrieval:
         [
             ("test_domain", "test_dataset", "PUBLIC", SensitivityLevel.PUBLIC),
             ("sample", "other", "PRIVATE", SensitivityLevel.PRIVATE),
-            ("hi", "there", "SENSITIVE", SensitivityLevel.SENSITIVE),
+            ("hi", "there", "PROTECTED", SensitivityLevel.PROTECTED),
         ],
     )
     def test_retrieves_dataset_sensitivity(

--- a/test/api/application/services/test_authorisation_service.py
+++ b/test/api/application/services/test_authorisation_service.py
@@ -243,8 +243,8 @@ class TestAcceptedScopes:
                 ["WRITE_PUBLIC"],
             ),
             # Standalone action endpoints
-            (AcceptedScopes(required={"ADD_CLIENT"}, optional=set()), ["ADD_CLIENT"]),
-            (AcceptedScopes(required={"ADD_SCHEMA"}, optional=set()), ["ADD_SCHEMA"]),
+            (AcceptedScopes(required={"USER_ADMIN"}, optional=set()), ["USER_ADMIN"]),
+            (AcceptedScopes(required={"DATA_ADMIN"}, optional=set()), ["DATA_ADMIN"]),
         ],
     )
     def test_scopes_satisfy_acceptable_scopes(
@@ -266,8 +266,8 @@ class TestAcceptedScopes:
                 ["READ_PUBLIC", "READ_ALL"],
             ),
             # Standalone action endpoints
-            (AcceptedScopes(required={"ADD_CLIENT"}, optional=set()), ["READ_ALL"]),
-            (AcceptedScopes(required={"ADD_SCHEMA"}, optional=set()), ["WRITE_ALL"]),
+            (AcceptedScopes(required={"USER_ADMIN"}, optional=set()), ["READ_ALL"]),
+            (AcceptedScopes(required={"DATA_ADMIN"}, optional=set()), ["WRITE_ALL"]),
         ],
     )
     def test_scopes_do_not_satisfy_acceptable_scopes(
@@ -295,31 +295,20 @@ class TestAppPermissionsMatching:
                         "READ_ALL",
                         "READ_PUBLIC",
                         "READ_PRIVATE",
-                        "READ_SENSITIVE",
                     },
                 ),
             ),
             (
                 "domain",
                 "dataset",
-                SensitivityLevel.SENSITIVE,
-                ["WRITE"],
-                AcceptedScopes(  # noqa: E126
-                    required=set(), optional={"WRITE_ALL", "WRITE_SENSITIVE"}
-                ),
-            ),
-            (
-                "domain",
-                "dataset",
                 SensitivityLevel.PUBLIC,
-                ["ADD_CLIENT", "READ"],
+                ["USER_ADMIN", "READ"],
                 AcceptedScopes(  # noqa: E126
-                    required={"ADD_CLIENT"},
+                    required={"USER_ADMIN"},
                     optional={
                         "READ_ALL",
                         "READ_PUBLIC",
                         "READ_PRIVATE",
-                        "READ_SENSITIVE",
                     },
                 ),
             ),
@@ -327,16 +316,14 @@ class TestAppPermissionsMatching:
                 "domain",
                 "dataset",
                 SensitivityLevel.PRIVATE,
-                ["ADD_CLIENT", "READ", "WRITE"],  # noqa: E126
+                ["USER_ADMIN", "READ", "WRITE"],  # noqa: E126
                 AcceptedScopes(  # noqa: E126
-                    required={"ADD_CLIENT"},
+                    required={"USER_ADMIN"},
                     optional={
                         "READ_ALL",
                         "WRITE_ALL",
                         "READ_PRIVATE",
                         "WRITE_PRIVATE",
-                        "READ_SENSITIVE",
-                        "WRITE_SENSITIVE",
                     },
                 ),
             ),
@@ -344,8 +331,8 @@ class TestAppPermissionsMatching:
                 None,
                 None,
                 None,
-                ["ADD_CLIENT"],
-                AcceptedScopes(required={"ADD_CLIENT"}, optional=set()),  # noqa: E126
+                ["USER_ADMIN"],
+                AcceptedScopes(required={"USER_ADMIN"}, optional=set()),  # noqa: E126
             ),
         ],
     )
@@ -371,13 +358,6 @@ class TestAppPermissionsMatching:
             # Token with correct action and sensitivity privilege
             ("domain", "dataset", SensitivityLevel.PUBLIC, ["READ_PUBLIC"], ["READ"]),
             ("domain", "dataset", SensitivityLevel.PRIVATE, ["READ_PRIVATE"], ["READ"]),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.SENSITIVE,
-                ["READ_SENSITIVE"],
-                ["READ"],
-            ),
             ("domain", "dataset", SensitivityLevel.PUBLIC, ["WRITE_PUBLIC"], ["WRITE"]),
             (
                 "domain",
@@ -386,50 +366,13 @@ class TestAppPermissionsMatching:
                 ["WRITE_PRIVATE"],
                 ["WRITE"],
             ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.SENSITIVE,
-                ["WRITE_SENSITIVE"],
-                ["WRITE"],
-            ),
             # Token with ALL permission
             ("domain", "dataset", SensitivityLevel.PUBLIC, ["READ_ALL"], ["READ"]),
             ("domain", "dataset", SensitivityLevel.PRIVATE, ["READ_ALL"], ["READ"]),
-            ("domain", "dataset", SensitivityLevel.SENSITIVE, ["READ_ALL"], ["READ"]),
             ("domain", "dataset", SensitivityLevel.PUBLIC, ["WRITE_ALL"], ["WRITE"]),
             ("domain", "dataset", SensitivityLevel.PRIVATE, ["WRITE_ALL"], ["WRITE"]),
-            ("domain", "dataset", SensitivityLevel.SENSITIVE, ["WRITE_ALL"], ["WRITE"]),
             # Higher sensitivity levels imply lower ones
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.PRIVATE,
-                ["READ_SENSITIVE"],
-                ["READ"],
-            ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.PUBLIC,
-                ["READ_SENSITIVE"],
-                ["READ"],
-            ),
             ("domain", "dataset", SensitivityLevel.PUBLIC, ["READ_PRIVATE"], ["READ"]),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.PRIVATE,
-                ["WRITE_SENSITIVE"],
-                ["WRITE"],
-            ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.PUBLIC,
-                ["WRITE_SENSITIVE"],
-                ["WRITE"],
-            ),
             (
                 "domain",
                 "dataset",
@@ -438,8 +381,8 @@ class TestAppPermissionsMatching:
                 ["WRITE"],
             ),
             # Standalone scopes (no domain or dataset, different type of action)
-            (None, None, None, ["ADD_CLIENT"], ["ADD_CLIENT"]),
-            (None, None, None, ["ADD_SCHEMA"], ["ADD_SCHEMA"]),
+            (None, None, None, ["USER_ADMIN"], ["USER_ADMIN"]),
+            (None, None, None, ["DATA_ADMIN"], ["DATA_ADMIN"]),
         ],
     )
     def test_matches_permissions(
@@ -466,64 +409,20 @@ class TestAppPermissionsMatching:
             # Token does not have required action privilege
             ("domain", "dataset", SensitivityLevel.PUBLIC, ["READ_PUBLIC"], ["WRITE"]),
             # Token does not have required sensitivity privilege
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.SENSITIVE,
-                ["READ_PUBLIC"],
-                ["READ"],
-            ),
             ("domain", "dataset", SensitivityLevel.PRIVATE, ["READ_PUBLIC"], ["READ"]),
             (
                 "domain",
                 "dataset",
-                SensitivityLevel.SENSITIVE,
-                ["WRITE_PUBLIC"],
-                ["WRITE"],
-            ),
-            (
-                "domain",
-                "dataset",
                 SensitivityLevel.PRIVATE,
                 ["WRITE_PUBLIC"],
                 ["WRITE"],
-            ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.SENSITIVE,
-                ["WRITE_PRIVATE"],
-                ["WRITE"],
-            ),
-            # WRITE does not imply READ at higher sensitivity level
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.SENSITIVE,
-                ["WRITE_PRIVATE"],
-                ["READ"],
             ),
             # Edge combinations
             # WRITE high sensitivity does not imply READ low sensitivity
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.PUBLIC,
-                ["WRITE_SENSITIVE"],
-                ["READ"],
-            ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.PRIVATE,
-                ["WRITE_SENSITIVE"],
-                ["READ"],
-            ),
             ("domain", "dataset", SensitivityLevel.PUBLIC, ["WRITE_PRIVATE"], ["READ"]),
             # WRITE does not imply READ
             ("domain", "dataset", SensitivityLevel.PUBLIC, ["WRITE_ALL"], ["READ"]),
             ("domain", "dataset", SensitivityLevel.PRIVATE, ["WRITE_ALL"], ["READ"]),
-            ("domain", "dataset", SensitivityLevel.SENSITIVE, ["WRITE_ALL"], ["READ"]),
         ],
     )
     def test_denies_permissions(

--- a/test/api/application/services/test_authorisation_service.py
+++ b/test/api/application/services/test_authorisation_service.py
@@ -242,13 +242,6 @@ class TestAcceptedScopes:
                 AcceptedScopes(required=set(), optional={"WRITE_PUBLIC"}),
                 ["WRITE_PUBLIC"],
             ),
-            # DELETE endpoint
-            (
-                AcceptedScopes(
-                    required=set(), optional={"DELETE_ALL", "DELETE_PUBLIC"}
-                ),
-                ["DELETE_PUBLIC"],
-            ),
             # Standalone action endpoints
             (AcceptedScopes(required={"ADD_CLIENT"}, optional=set()), ["ADD_CLIENT"]),
             (AcceptedScopes(required={"ADD_SCHEMA"}, optional=set()), ["ADD_SCHEMA"]),
@@ -271,11 +264,6 @@ class TestAcceptedScopes:
             (
                 AcceptedScopes(required=set(), optional={"WRITE_PUBLIC"}),
                 ["READ_PUBLIC", "READ_ALL"],
-            ),
-            # DELETE endpoint
-            (
-                AcceptedScopes(required=set(), optional={"DELETE_PUBLIC"}),
-                ["READ_PUBLIC", "WRITE_ALL"],
             ),
             # Standalone action endpoints
             (AcceptedScopes(required={"ADD_CLIENT"}, optional=set()), ["READ_ALL"]),
@@ -405,27 +393,6 @@ class TestAppPermissionsMatching:
                 ["WRITE_SENSITIVE"],
                 ["WRITE"],
             ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.PUBLIC,
-                ["DELETE_PUBLIC"],
-                ["DELETE"],
-            ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.PRIVATE,
-                ["DELETE_PRIVATE"],
-                ["DELETE"],
-            ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.SENSITIVE,
-                ["DELETE_SENSITIVE"],
-                ["DELETE"],
-            ),
             # Token with ALL permission
             ("domain", "dataset", SensitivityLevel.PUBLIC, ["READ_ALL"], ["READ"]),
             ("domain", "dataset", SensitivityLevel.PRIVATE, ["READ_ALL"], ["READ"]),
@@ -433,15 +400,6 @@ class TestAppPermissionsMatching:
             ("domain", "dataset", SensitivityLevel.PUBLIC, ["WRITE_ALL"], ["WRITE"]),
             ("domain", "dataset", SensitivityLevel.PRIVATE, ["WRITE_ALL"], ["WRITE"]),
             ("domain", "dataset", SensitivityLevel.SENSITIVE, ["WRITE_ALL"], ["WRITE"]),
-            ("domain", "dataset", SensitivityLevel.PUBLIC, ["DELETE_ALL"], ["DELETE"]),
-            ("domain", "dataset", SensitivityLevel.PRIVATE, ["DELETE_ALL"], ["DELETE"]),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.SENSITIVE,
-                ["DELETE_ALL"],
-                ["DELETE"],
-            ),
             # Higher sensitivity levels imply lower ones
             (
                 "domain",
@@ -478,27 +436,6 @@ class TestAppPermissionsMatching:
                 SensitivityLevel.PUBLIC,
                 ["WRITE_PRIVATE"],
                 ["WRITE"],
-            ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.PRIVATE,
-                ["DELETE_SENSITIVE"],
-                ["DELETE"],
-            ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.PUBLIC,
-                ["DELETE_SENSITIVE"],
-                ["DELETE"],
-            ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.PUBLIC,
-                ["DELETE_PRIVATE"],
-                ["DELETE"],
             ),
             # Standalone scopes (no domain or dataset, different type of action)
             (None, None, None, ["ADD_CLIENT"], ["ADD_CLIENT"]),
@@ -558,27 +495,6 @@ class TestAppPermissionsMatching:
                 ["WRITE_PRIVATE"],
                 ["WRITE"],
             ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.SENSITIVE,
-                ["DELETE_PUBLIC"],
-                ["DELETE"],
-            ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.PRIVATE,
-                ["DELETE_PUBLIC"],
-                ["DELETE"],
-            ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.SENSITIVE,
-                ["DELETE_PRIVATE"],
-                ["DELETE"],
-            ),
             # WRITE does not imply READ at higher sensitivity level
             (
                 "domain",
@@ -608,107 +524,6 @@ class TestAppPermissionsMatching:
             ("domain", "dataset", SensitivityLevel.PUBLIC, ["WRITE_ALL"], ["READ"]),
             ("domain", "dataset", SensitivityLevel.PRIVATE, ["WRITE_ALL"], ["READ"]),
             ("domain", "dataset", SensitivityLevel.SENSITIVE, ["WRITE_ALL"], ["READ"]),
-            # READ or WRITE does not imply DELETE
-            ("domain", "dataset", SensitivityLevel.PUBLIC, ["READ_ALL"], ["DELETE"]),
-            ("domain", "dataset", SensitivityLevel.PRIVATE, ["READ_ALL"], ["DELETE"]),
-            ("domain", "dataset", SensitivityLevel.SENSITIVE, ["READ_ALL"], ["DELETE"]),
-            ("domain", "dataset", SensitivityLevel.PUBLIC, ["WRITE_ALL"], ["DELETE"]),
-            ("domain", "dataset", SensitivityLevel.PRIVATE, ["WRITE_ALL"], ["DELETE"]),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.SENSITIVE,
-                ["WRITE_ALL"],
-                ["DELETE"],
-            ),
-            # DELETE does not imply READ or WRITE
-            ("domain", "dataset", SensitivityLevel.PUBLIC, ["DELETE_ALL"], ["READ"]),
-            ("domain", "dataset", SensitivityLevel.PRIVATE, ["DELETE_ALL"], ["READ"]),
-            ("domain", "dataset", SensitivityLevel.SENSITIVE, ["DELETE_ALL"], ["READ"]),
-            ("domain", "dataset", SensitivityLevel.PUBLIC, ["DELETE_ALL"], ["WRITE"]),
-            ("domain", "dataset", SensitivityLevel.PRIVATE, ["DELETE_ALL"], ["WRITE"]),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.SENSITIVE,
-                ["DELETE_ALL"],
-                ["WRITE"],
-            ),
-            # DELETE does not imply READ or WRITE at a sensitivity level
-            ("domain", "dataset", SensitivityLevel.PUBLIC, ["DELETE_PUBLIC"], ["READ"]),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.PRIVATE,
-                ["DELETE_PRIVATE"],
-                ["READ"],
-            ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.SENSITIVE,
-                ["DELETE_SENSITIVE"],
-                ["READ"],
-            ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.PUBLIC,
-                ["DELETE_PUBLIC"],
-                ["WRITE"],
-            ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.PRIVATE,
-                ["DELETE_PRIVATE"],
-                ["WRITE"],
-            ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.SENSITIVE,
-                ["DELETE_SENSITIVE"],
-                ["WRITE"],
-            ),
-            # READ does not imply DELETE at a sensitivity level
-            ("domain", "dataset", SensitivityLevel.PUBLIC, ["READ_PUBLIC"], ["DELETE"]),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.PRIVATE,
-                ["READ_PRIVATE"],
-                ["DELETE"],
-            ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.SENSITIVE,
-                ["READ_SENSITIVE"],
-                ["DELETE"],
-            ),
-            # WRITE does not imply DELETE at a sensitivity level
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.PUBLIC,
-                ["WRITE_PUBLIC"],
-                ["DELETE"],
-            ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.PRIVATE,
-                ["WRITE_PRIVATE"],
-                ["DELETE"],
-            ),
-            (
-                "domain",
-                "dataset",
-                SensitivityLevel.SENSITIVE,
-                ["WRITE_SENSITIVE"],
-                ["DELETE"],
-            ),
         ],
     )
     def test_denies_permissions(
@@ -739,7 +554,6 @@ class TestUserPermissionsMatching:
             # Token with correct action and sensitivity privilege
             ("domain", "dataset", ["READ/domain/dataset"], ["READ"]),
             ("domain", "dataset", ["WRITE/domain/dataset"], ["WRITE"]),
-            ("domain", "dataset", ["DELETE/domain/dataset"], ["DELETE"]),
         ],
     )
     def test_matches_permissions(
@@ -762,8 +576,6 @@ class TestUserPermissionsMatching:
             ("domain", "dataset", ["WRITE/domain/dataset"], ["READ"]),
             ("domain", "dataset", ["READ/domain1/dataset"], ["READ"]),
             ("domain", "dataset", ["WRITE/domain/dataset1"], ["WRITE"]),
-            ("domain", "dataset", ["DELETE/domain1/dataset"], ["DELETE"]),
-            ("domain", "dataset", ["DELETE/domain/dataset1"], ["DELETE"]),
         ],
     )
     def test_denies_permissions(

--- a/test/api/application/services/test_schema_validation.py
+++ b/test/api/application/services/test_schema_validation.py
@@ -619,7 +619,7 @@ class TestSchemaValidation:
 
         self._assert_validate_schema_raises_error(
             invalid_schema,
-            r"You must specify a valid sensitivity level. Accepted values: \['PUBLIC', 'PRIVATE', 'SENSITIVE', 'PROTECTED'\]",
+            r"You must specify a valid sensitivity level. Accepted values: \['PUBLIC', 'PRIVATE', 'PROTECTED'\]",
         )
 
     def test_valid_schema_when_all_custom_tags_are_set(self):

--- a/test/api/application/services/test_schema_validation.py
+++ b/test/api/application/services/test_schema_validation.py
@@ -588,7 +588,6 @@ class TestSchemaValidation:
             # lowercase versions of accepted values
             "public",
             "private",
-            "sensitive",
             "protected",
             # blatantly incorrect values
             "WRONG",

--- a/test/api/test_entry.py
+++ b/test/api/test_entry.py
@@ -49,7 +49,7 @@ class TestUploadPage(BaseClientTest):
         mock_extract_users.return_value = [
             "WRITE/domain1/dataset1",
             "WRITE/domain2/dataset2",
-            "ADD_CLIENT",
+            "USER_ADMIN",
             "READ/domain2/dataset2",
         ]
 

--- a/test/e2e/test_journey.py
+++ b/test/e2e/test_journey.py
@@ -135,7 +135,7 @@ class TestAuthenticatedJourneys(BaseJourneyTest):
         payload = {
             "grant_type": "client_credentials",
             "client_id": self.cognito_client_id,
-            "scope": f"https://{DOMAIN_NAME}/READ_ALL https://{DOMAIN_NAME}/WRITE_ALL https://{DOMAIN_NAME}/DELETE_ALL",
+            "scope": f"https://{DOMAIN_NAME}/READ_ALL https://{DOMAIN_NAME}/WRITE_ALL",
         }
 
         response = requests.post(


### PR DESCRIPTION
- Change the access levels, removing SENSITIVE. Leaving us with PUBLIC, PRIVATE and PROTECTED
- Remove DELETE permissions (merging these with WRITE)
- Change the ADD_SCHEMA permission to DATA_ADMIN
- Change the ADD_CLIENT permission to USER_ADMIN