### PR TITLE
feat: add parameter store functionality to retain infrastructure state

### DIFF
--- a/api/adapter/ssm_adapter.py
+++ b/api/adapter/ssm_adapter.py
@@ -1,0 +1,20 @@
+import boto3
+
+from api.adapter.base_aws_adapter import BaseAWSAdapter
+from api.common.config.aws import AWS_REGION
+
+
+class SSMAdapter(BaseAWSAdapter):
+    def __init__(self, ssm_client=boto3.client("ssm", region_name=AWS_REGION)):
+        self._ssm_client = ssm_client
+
+    def get_parameter(self, name: str) -> str:
+        response = self._ssm_client.get_parameter(Name=name)
+        self.validate_response(response)
+        return response["Parameter"]["Value"]
+
+    def put_parameter(self, name: str, value: str):
+        response = self._ssm_client.put_parameter(
+            Name=name, Value=value, Overwrite=True
+        )
+        self.validate_response(response)

--- a/api/application/services/protected_domain_service.py
+++ b/api/application/services/protected_domain_service.py
@@ -37,6 +37,9 @@ class ProtectedDomainService:
         self.append_scopes_to_parameter(scopes)
 
     def append_scopes_to_parameter(self, additional_scopes: List[dict]):
+        """
+        This is to ensure that any user added scopes can be picked up by the terraform infrastructure
+        """
         scopes = json.loads(
             self.ssm_adapter.get_parameter(PROTECTED_DOMAIN_SCOPES_PARAMETER_NAME)
         )

--- a/api/application/services/protected_domain_service.py
+++ b/api/application/services/protected_domain_service.py
@@ -1,34 +1,48 @@
+from dataclasses import dataclass
+import json
 from typing import List
 
 
 from api.adapter.cognito_adapter import CognitoAdapter
+from api.adapter.ssm_adapter import SSMAdapter
 from api.common.config.auth import (
     COGNITO_RESOURCE_SERVER_ID,
     COGNITO_USER_POOL_ID,
+    PROTECTED_DOMAIN_SCOPES_PARAMETER_NAME,
     Action,
     SensitivityLevel,
 )
 
 
 class ProtectedDomainService:
-    def __init__(self, cognito_adapter=CognitoAdapter()):
+    def __init__(self, cognito_adapter=CognitoAdapter(), ssm_adapter=SSMAdapter()):
         self.cognito_adapter = cognito_adapter
+        self.ssm_adapter = ssm_adapter
 
     def create_scopes(self, domain: str):
         domain = domain.upper().strip()
+        scopes = [
+            {
+                "ScopeName": f"{Action.READ.value}_{SensitivityLevel.PROTECTED.value}_{domain}",
+                "ScopeDescription": f"Read from the protected domain of {domain}",
+            },
+            {
+                "ScopeName": f"{Action.WRITE.value}_{SensitivityLevel.PROTECTED.value}_{domain}",
+                "ScopeDescription": f"Write to the protected domain of {domain}",
+            },
+        ]
         self.cognito_adapter.add_resource_server_scopes(
-            COGNITO_USER_POOL_ID,
-            COGNITO_RESOURCE_SERVER_ID,
-            [
-                {
-                    "ScopeName": f"{Action.READ.value}_{SensitivityLevel.PROTECTED.value}_{domain}",
-                    "ScopeDescription": f"Read from the protected domain of {domain}",
-                },
-                {
-                    "ScopeName": f"{Action.WRITE.value}_{SensitivityLevel.PROTECTED.value}_{domain}",
-                    "ScopeDescription": f"Write to the protected domain of {domain}",
-                },
-            ],
+            COGNITO_USER_POOL_ID, COGNITO_RESOURCE_SERVER_ID, scopes
+        )
+        self.append_scopes_to_parameter(scopes)
+
+    def append_scopes_to_parameter(self, additional_scopes: List[dict]):
+        scopes = json.loads(
+            self.ssm_adapter.get_parameter(PROTECTED_DOMAIN_SCOPES_PARAMETER_NAME)
+        )
+        scopes.extend(additional_scopes)
+        self.ssm_adapter.put_parameter(
+            PROTECTED_DOMAIN_SCOPES_PARAMETER_NAME, json.dumps(scopes)
         )
 
     def list_domains(self) -> List[str]:

--- a/api/common/config/auth.py
+++ b/api/common/config/auth.py
@@ -43,6 +43,7 @@ COGNITO_USER_LOGIN_APP_CREDENTIALS_SECRETS_NAME = os.getenv(
     "COGNITO_USER_LOGIN_APP_CREDENTIALS_SECRETS_NAME", "rapid_cognito_user_secrets"
 )
 COGNITO_REDIRECT_URI = f"https://{DOMAIN_NAME}/oauth2/success"
+PROTECTED_DOMAIN_SCOPES_PARAMETER_NAME = RESOURCE_PREFIX + "_protected_domain_scopes"
 
 
 def construct_user_auth_url(client_id: str):
@@ -61,7 +62,6 @@ class Action(BaseEnum):
 
 
 # Classifications
-# TODO: Review the naming of these
 class SensitivityLevel(BaseEnum):
     PUBLIC = "PUBLIC"
     PRIVATE = "PRIVATE"

--- a/test/api/adapter/test_ssm_adapter.py
+++ b/test/api/adapter/test_ssm_adapter.py
@@ -1,0 +1,36 @@
+from unittest.mock import Mock
+
+from api.adapter.ssm_adapter import SSMAdapter
+
+
+class TestSSMAdapter:
+    def setup_method(self):
+        self.ssm_boto_client = Mock()
+        self.ssm_adapter = SSMAdapter(self.ssm_boto_client)
+
+    def test_get_parameter(self):
+
+        mock_response = {
+            "Parameter": {
+                "Name": "name",
+                "Type": "String",
+                "Value": "value",
+            },
+            "ResponseMetadata": {"HTTPStatusCode": 200},
+        }
+        self.ssm_boto_client.get_parameter = Mock(return_value=mock_response)
+        response = self.ssm_adapter.get_parameter("name")
+        self.ssm_boto_client.get_parameter.assert_called_once_with(Name="name")
+        assert response == "value"
+
+    def test_put_parameter(self):
+        mock_response = {
+            "Version": 123,
+            "Tier": "Standard",
+            "ResponseMetadata": {"HTTPStatusCode": 200},
+        }
+        self.ssm_boto_client.put_parameter = Mock(return_value=mock_response)
+        self.ssm_adapter.put_parameter("name", "value")
+        self.ssm_boto_client.put_parameter.assert_called_once_with(
+            Name="name", Value="value", Overwrite=True
+        )

--- a/test/api/application/services/test_protected_domain_service.py
+++ b/test/api/application/services/test_protected_domain_service.py
@@ -3,10 +3,21 @@ from unittest.mock import Mock
 from typing import List
 
 from api.application.services.protected_domain_service import ProtectedDomainService
-from api.common.config.auth import COGNITO_USER_POOL_ID, COGNITO_RESOURCE_SERVER_ID
+from api.common.config.auth import (
+    COGNITO_USER_POOL_ID,
+    COGNITO_RESOURCE_SERVER_ID,
+    PROTECTED_DOMAIN_SCOPES_PARAMETER_NAME,
+)
 
 
 class TestProtectedDomainService:
+    def setup_method(self):
+        self.cognito_adapter = Mock()
+        self.ssm_adapter = Mock()
+        self.protected_domain_service = ProtectedDomainService(
+            self.cognito_adapter, self.ssm_adapter
+        )
+
     def test_create_scopes(self):
         expected_scopes = [
             {
@@ -19,12 +30,15 @@ class TestProtectedDomainService:
             },
         ]
 
-        protected_domain_service = ProtectedDomainService(Mock())
+        self.cognito_adapter.add_resource_server_scopes = Mock()
+        self.protected_domain_service.append_scopes_to_parameter = Mock()
 
-        protected_domain_service.cognito_adapter.add_resource_server_scopes = Mock()
-        protected_domain_service.create_scopes("domain")
-        protected_domain_service.cognito_adapter.add_resource_server_scopes.assert_called_once_with(
+        self.protected_domain_service.create_scopes("domain")
+        self.cognito_adapter.add_resource_server_scopes.assert_called_once_with(
             COGNITO_USER_POOL_ID, COGNITO_RESOURCE_SERVER_ID, expected_scopes
+        )
+        self.protected_domain_service.append_scopes_to_parameter.assert_called_once_with(
+            expected_scopes
         )
 
     @pytest.mark.parametrize(
@@ -54,13 +68,26 @@ class TestProtectedDomainService:
             ]
         }
 
-        protected_domain_service = ProtectedDomainService(Mock())
-        protected_domain_service.cognito_adapter.get_resource_server = Mock(
-            return_value=mock_response
+        self.cognito_adapter.get_resource_server = Mock(return_value=mock_response)
+
+        res = self.protected_domain_service.list_domains()
+        assert res == sorted(expected_response)
+        self.cognito_adapter.get_resource_server.assert_called_once_with(
+            COGNITO_USER_POOL_ID, COGNITO_RESOURCE_SERVER_ID
         )
 
-        res = protected_domain_service.list_domains()
-        assert res == sorted(expected_response)
-        protected_domain_service.cognito_adapter.get_resource_server.assert_called_once_with(
-            COGNITO_USER_POOL_ID, COGNITO_RESOURCE_SERVER_ID
+    def test_append_scopes_to_parameter(self):
+        mock_response = '[{"ScopeName": "old", "ScopeDescription": "old"}]'
+        new_scope = [{"ScopeName": "new", "ScopeDescription": "new"}]
+
+        self.ssm_adapter.get_parameter = Mock(return_value=mock_response)
+        self.ssm_adapter.put_parameter = Mock()
+
+        self.protected_domain_service.append_scopes_to_parameter(new_scope)
+        self.ssm_adapter.get_parameter.assert_called_once_with(
+            PROTECTED_DOMAIN_SCOPES_PARAMETER_NAME
+        )
+        self.ssm_adapter.put_parameter.assert_called_once_with(
+            PROTECTED_DOMAIN_SCOPES_PARAMETER_NAME,
+            '[{"ScopeName": "old", "ScopeDescription": "old"}, {"ScopeName": "new", "ScopeDescription": "new"}]',
         )


### PR DESCRIPTION
This change writes any new protected domain scopes to parameter store so that they can be retrieved in the terraform. This means that any scopes created by users will not be destroyed with infrastructure changes.

Testing - 100% coverage on changed files