### PR TITLE
add resource_prefix to crawler name

### DIFF
--- a/api/adapter/athena_adapter.py
+++ b/api/adapter/athena_adapter.py
@@ -50,6 +50,6 @@ class DatasetQuery:
     def _handle_query_error(self, error, table_name):
         if re.match(".+ Table .+ does not exist", error.args[0]):
             raise UserError(
-                f"Query failed to execute: The table [{table_name}] does not exist. Please check your spelling or there may be no data yet"
+                f"Query failed to execute: The table [{table_name}] does not exist. The data could be currently processing or you might need to upload it."
             )
         raise UserError(f"Query failed to execute: {error.args[0]}")

--- a/api/adapter/glue_adapter.py
+++ b/api/adapter/glue_adapter.py
@@ -153,7 +153,7 @@ class GlueAdapter:
             )
 
     def _generate_crawler_name(self, resource_prefix: str, domain: str, dataset: str) -> str:
-        return resource_prefix + "_rapid_crawler/" + domain + "/" + dataset
+        return resource_prefix + "_crawler/" + domain + "/" + dataset
 
     def _handle_crawler_create_error(self, error: ClientError):
         if error.response["Error"]["Code"] == "AlreadyExistsException":

--- a/api/adapter/glue_adapter.py
+++ b/api/adapter/glue_adapter.py
@@ -42,11 +42,11 @@ class GlueAdapter:
         self.glue_crawler_role = glue_crawler_role
         self.glue_connection_name = glue_connection_name
 
-    def create_crawler(self, domain: str, dataset: str, tags: Dict[str, str]):
+    def create_crawler(self, resource_prefix: str, domain: str, dataset: str, tags: Dict[str, str]):
         data_store = StorageMetaData(domain, dataset)
         try:
             self.glue_client.create_crawler(
-                Name=self._generate_crawler_name(domain, dataset),
+                Name=self._generate_crawler_name(resource_prefix, domain, dataset),
                 Role=self.glue_crawler_role,
                 DatabaseName=self.glue_catalogue_db_name,
                 TablePrefix=data_store.glue_table_prefix(),
@@ -66,26 +66,26 @@ class GlueAdapter:
         except ClientError as error:
             self._handle_crawler_create_error(error)
 
-    def start_crawler(self, domain: str, dataset: str):
+    def start_crawler(self, resource_prefix: str, domain: str, dataset: str):
         try:
             self.glue_client.start_crawler(
-                Name=self._generate_crawler_name(domain, dataset)
+                Name=self._generate_crawler_name(resource_prefix, domain, dataset)
             )
         except ClientError:
             raise CrawlerStartFailsError("Failed to start crawler")
 
-    def delete_crawler(self, domain: str, dataset: str):
+    def delete_crawler(self, resource_prefix: str, domain: str, dataset: str):
         try:
             self.glue_client.delete_crawler(
-                self._generate_crawler_name(domain, dataset)
+                self._generate_crawler_name(resource_prefix, domain, dataset)
             )
         except ClientError:
             raise CrawlerDeleteFailsError("Failed to delete crawler")
 
-    def check_crawler_is_ready(self, domain: str, dataset: str):
-        if self._get_crawler_state(domain, dataset) != "READY":
+    def check_crawler_is_ready(self, resource_prefix: str, domain: str, dataset: str):
+        if self._get_crawler_state(resource_prefix, domain, dataset) != "READY":
             raise CrawlerIsNotReadyError(
-                f"Crawler is not ready for domain={domain} and dataset={dataset}"
+                f"Crawler is not ready for resource_prefix={resource_prefix}, domain={domain} and dataset={dataset}"
             )
 
     def update_catalog_table_config(self, domain: str, dataset: str):
@@ -141,19 +141,19 @@ class GlueAdapter:
             "StorageDescriptor": table_storage_desc,
         }
 
-    def _get_crawler_state(self, domain: str, dataset: str) -> str:
+    def _get_crawler_state(self, resource_prefix: str, domain: str, dataset: str) -> str:
         try:
             response = self.glue_client.get_crawler(
-                Name=self._generate_crawler_name(domain, dataset)
+                Name=self._generate_crawler_name(resource_prefix, domain, dataset)
             )
             return response["Crawler"]["State"]
         except ClientError:
             raise GetCrawlerError(
-                f"Failed to get crawler state domain = {domain} dataset = {dataset}"
+                f"Failed to get crawler state resource_prefix={resource_prefix}, domain = {domain} dataset = {dataset}"
             )
 
-    def _generate_crawler_name(self, domain: str, dataset: str) -> str:
-        return "rapid_crawler/" + domain + "/" + dataset
+    def _generate_crawler_name(self, resource_prefix: str, domain: str, dataset: str) -> str:
+        return resource_prefix + "_rapid_crawler/" + domain + "/" + dataset
 
     def _handle_crawler_create_error(self, error: ClientError):
         if error.response["Error"]["Code"] == "AlreadyExistsException":

--- a/api/application/services/data_service.py
+++ b/api/application/services/data_service.py
@@ -66,7 +66,7 @@ class DataService:
         return raw_filename, permanent_filename
 
     def upload_dataset(
-        self, domain: str, dataset: str, filename: str, file_contents: str
+        self, resource_prefix: str, domain: str, dataset: str, filename: str, file_contents: str
     ) -> str:
         schema = self._get_schema(domain, dataset)
         if not schema:
@@ -74,7 +74,7 @@ class DataService:
                 f"Could not find schema related to the dataset [{dataset}]"
             )
         else:
-            self.glue_adapter.check_crawler_is_ready(domain, dataset)
+            self.glue_adapter.check_crawler_is_ready(resource_prefix, domain, dataset)
             validated_dataframe = get_validated_dataframe(schema, file_contents)
             raw_filname, permanent_filename = self.generate_raw_and_permanent_filenames(
                 schema, filename
@@ -86,7 +86,7 @@ class DataService:
                 file_contents,
             )
             self._upload_data(schema, validated_dataframe, permanent_filename)
-            self.glue_adapter.start_crawler(domain, dataset)
+            self.glue_adapter.start_crawler(resource_prefix, domain, dataset)
             self.glue_adapter.update_catalog_table_config(domain, dataset)
             return permanent_filename
 

--- a/api/application/services/delete_service.py
+++ b/api/application/services/delete_service.py
@@ -14,12 +14,12 @@ class DeleteService:
     def delete_schema(self, domain: str, dataset: str, sensitivity: str):
         self.persistence_adapter.delete_schema(domain, dataset, sensitivity)
 
-    def delete_dataset_file(self, domain: str, dataset: str, filename: str):
+    def delete_dataset_file(self, resource_prefix: str, domain: str, dataset: str, filename: str):
         self._validate_filename(filename)
         self.persistence_adapter.find_raw_file(domain, dataset, filename)
-        self.glue_adapter.check_crawler_is_ready(domain, dataset)
+        self.glue_adapter.check_crawler_is_ready(resource_prefix, domain, dataset)
         self.persistence_adapter.delete_dataset_files(domain, dataset, filename)
-        self.glue_adapter.start_crawler(domain, dataset)
+        self.glue_adapter.start_crawler(resource_prefix, domain, dataset)
 
     def _validate_filename(self, filename: str):
         if not re.match(FILENAME_WITH_TIMESTAMP_REGEX, filename):

--- a/api/controller/datasets.py
+++ b/api/controller/datasets.py
@@ -29,6 +29,7 @@ from api.controller.utils import _response_body
 from api.domain.dataset_filter_query import DatasetFilterQuery
 from api.domain.mime_type import MimeType
 from api.domain.sql_query import SQLQuery
+from api.common.config.aws import RESOURCE_PREFIX
 
 resource_adapter = AWSResourceAdapter()
 data_service = DataService()
@@ -249,7 +250,7 @@ async def upload_data(
     try:
         file_contents = await file.read()
         filename = data_service.upload_dataset(
-            domain, dataset, file.filename, file_contents
+            RESOURCE_PREFIX, domain, dataset, file.filename, file_contents
         )
         return _response_body(filename)
     except SchemaNotFoundError as error:

--- a/api/controller/datasets.py
+++ b/api/controller/datasets.py
@@ -193,7 +193,7 @@ async def delete_data_file(
 
     """
     try:
-        delete_service.delete_dataset_file(domain, dataset, filename)
+        delete_service.delete_dataset_file(RESOURCE_PREFIX, domain, dataset, filename)
         return Response(status_code=http_status.HTTP_204_NO_CONTENT)
     except CrawlerIsNotReadyError as error:
         AppLogger.warning("File deletion did not occur: %s", error.args[0])

--- a/api/controller/schema.py
+++ b/api/controller/schema.py
@@ -18,6 +18,7 @@ from api.common.custom_exceptions import (
 from api.common.logger import AppLogger
 from api.controller.utils import _response_body
 from api.domain.schema import Schema
+from api.common.config.aws import RESOURCE_PREFIX
 
 data_service = DataService()
 schema_infer_service = SchemaInferService()
@@ -91,7 +92,7 @@ async def upload_schema(schema: Schema):
         schema_file_name = data_service.upload_schema(schema)
         cognito_adapter.create_user_groups(schema.get_domain(), schema.get_dataset())
         glue_adapter.create_crawler(
-            schema.get_domain(), schema.get_dataset(), schema.get_tags()
+            RESOURCE_PREFIX, schema.get_domain(), schema.get_dataset(), schema.get_tags()
         )
         return _response_body(schema_file_name)
     except ProtectedDomainDoesNotExistError as error:

--- a/test/api/adapter/test_athena_adapter.py
+++ b/test/api/adapter/test_athena_adapter.py
@@ -94,7 +94,7 @@ class TestAthenaAdapter:
             "SYNTAX_ERROR: line 1:15: Table awsdatacatalog.rapid_catalogue_db.my_table does not exist"
         )
 
-        expected_message = r"Query failed to execute: The table \[my_table\] does not exist. Please check your spelling or there may be no data yet"
+        expected_message = r"Query failed to execute: The table \[my_table\] does not exist. The data could be currently processing or you might need to upload it."
 
         with pytest.raises(UserError, match=expected_message):
             self.dataset_query.query("my", "table", SQLQuery())

--- a/test/api/adapter/test_glue_adapter.py
+++ b/test/api/adapter/test_glue_adapter.py
@@ -5,6 +5,7 @@ from botocore.exceptions import ClientError
 
 from api.adapter.glue_adapter import GlueAdapter
 from api.common.config.aws import GLUE_TABLE_PRESENCE_CHECK_RETRY_COUNT, GLUE_CSV_CLASSIFIER, DATA_BUCKET
+from api.common.config.aws import RESOURCE_PREFIX
 from api.common.custom_exceptions import (
     CrawlerCreateFailsError,
     CrawlerStartFailsError,
@@ -29,10 +30,10 @@ class TestGlueAdapterCrawlerMethods:
 
     def test_create_crawler(self):
         self.glue_adapter.create_crawler(
-            "resource_prefix", "domain", "dataset", {"tag1": "value1", "tag2": "value2", "tag3": "value3"}
+            RESOURCE_PREFIX, "domain", "dataset", {"tag1": "value1", "tag2": "value2", "tag3": "value3"}
         )
         self.glue_boto_client.create_crawler.assert_called_once_with(
-            Name="resource_prefix_rapid_crawler/domain/dataset",
+            Name=RESOURCE_PREFIX + "_rapid_crawler/domain/dataset",
             Role="GLUE_CRAWLER_ROLE",
             DatabaseName="GLUE_CATALOGUE_DB_NAME",
             TablePrefix="domain_",
@@ -59,7 +60,7 @@ class TestGlueAdapterCrawlerMethods:
         )
 
         with pytest.raises(CrawlerCreateFailsError):
-            self.glue_adapter.create_crawler("resource_prefix", "domain", "dataset", {})
+            self.glue_adapter.create_crawler(RESOURCE_PREFIX, "domain", "dataset", {})
 
     def test_create_crawler_fails(self):
         self.glue_boto_client.create_crawler.side_effect = ClientError(
@@ -68,12 +69,12 @@ class TestGlueAdapterCrawlerMethods:
         )
 
         with pytest.raises(CrawlerCreateFailsError):
-            self.glue_adapter.create_crawler("resource_prefix", "domain", "dataset", {})
+            self.glue_adapter.create_crawler(RESOURCE_PREFIX, "domain", "dataset", {})
 
     def test_start_crawler(self):
-        self.glue_adapter.start_crawler("resource_prefix", "domain", "dataset")
+        self.glue_adapter.start_crawler(RESOURCE_PREFIX, "domain", "dataset")
         self.glue_boto_client.start_crawler.assert_called_once_with(
-            Name="resource_prefix_rapid_crawler/domain/dataset"
+            Name=RESOURCE_PREFIX + "_rapid_crawler/domain/dataset"
         )
 
     def test_start_crawler_fails(self):
@@ -83,12 +84,12 @@ class TestGlueAdapterCrawlerMethods:
         )
 
         with pytest.raises(CrawlerStartFailsError):
-            self.glue_adapter.start_crawler("resource_prefix", "domain", "dataset")
+            self.glue_adapter.start_crawler(RESOURCE_PREFIX, "domain", "dataset")
 
     def test_delete_crawler(self):
-        self.glue_adapter.delete_crawler("resource_prefix", "domain", "dataset")
+        self.glue_adapter.delete_crawler(RESOURCE_PREFIX, "domain", "dataset")
         self.glue_boto_client.delete_crawler.assert_called_once_with(
-            "resource_prefix_rapid_crawler/domain/dataset"
+            RESOURCE_PREFIX + "_rapid_crawler/domain/dataset"
         )
 
     def test_delete_crawler_fails(self):
@@ -98,7 +99,7 @@ class TestGlueAdapterCrawlerMethods:
         )
 
         with pytest.raises(CrawlerDeleteFailsError):
-            self.glue_adapter.delete_crawler("resource_prefix", "domain", "dataset")
+            self.glue_adapter.delete_crawler(RESOURCE_PREFIX, "domain", "dataset")
 
     def test_fails_to_check_if_crawler_is_running(self):
         self.glue_boto_client.get_crawler.side_effect = ClientError(
@@ -107,7 +108,7 @@ class TestGlueAdapterCrawlerMethods:
         )
 
         with pytest.raises(GetCrawlerError):
-            self.glue_adapter.check_crawler_is_ready("resource_prefix", "domain", "dataset")
+            self.glue_adapter.check_crawler_is_ready(RESOURCE_PREFIX, "domain", "dataset")
 
     def test_check_crawler_is_ready(self):
         self.glue_boto_client.get_crawler.return_value = {
@@ -115,9 +116,9 @@ class TestGlueAdapterCrawlerMethods:
                 "State": "READY",
             }
         }
-        self.glue_adapter.check_crawler_is_ready("resource_prefix", "domain", "dataset")
+        self.glue_adapter.check_crawler_is_ready(RESOURCE_PREFIX, "domain", "dataset")
         self.glue_boto_client.get_crawler.assert_called_once_with(
-            Name="resource_prefix_rapid_crawler/domain/dataset"
+            Name=RESOURCE_PREFIX + "_rapid_crawler/domain/dataset"
         )
 
     def test_check_crawler_is_not_ready(self):
@@ -128,10 +129,10 @@ class TestGlueAdapterCrawlerMethods:
                 }
             }
             with pytest.raises(CrawlerIsNotReadyError):
-                self.glue_adapter.check_crawler_is_ready("resource_prefix", "domain", "dataset")
+                self.glue_adapter.check_crawler_is_ready(RESOURCE_PREFIX, "domain", "dataset")
 
             self.glue_boto_client.get_crawler.assert_called_with(
-                Name="resource_prefix_rapid_crawler/domain/dataset"
+                Name=RESOURCE_PREFIX + "_rapid_crawler/domain/dataset"
             )
 
 

--- a/test/api/adapter/test_glue_adapter.py
+++ b/test/api/adapter/test_glue_adapter.py
@@ -33,7 +33,7 @@ class TestGlueAdapterCrawlerMethods:
             RESOURCE_PREFIX, "domain", "dataset", {"tag1": "value1", "tag2": "value2", "tag3": "value3"}
         )
         self.glue_boto_client.create_crawler.assert_called_once_with(
-            Name=RESOURCE_PREFIX + "_rapid_crawler/domain/dataset",
+            Name=RESOURCE_PREFIX + "_crawler/domain/dataset",
             Role="GLUE_CRAWLER_ROLE",
             DatabaseName="GLUE_CATALOGUE_DB_NAME",
             TablePrefix="domain_",
@@ -74,7 +74,7 @@ class TestGlueAdapterCrawlerMethods:
     def test_start_crawler(self):
         self.glue_adapter.start_crawler(RESOURCE_PREFIX, "domain", "dataset")
         self.glue_boto_client.start_crawler.assert_called_once_with(
-            Name=RESOURCE_PREFIX + "_rapid_crawler/domain/dataset"
+            Name=RESOURCE_PREFIX + "_crawler/domain/dataset"
         )
 
     def test_start_crawler_fails(self):
@@ -89,7 +89,7 @@ class TestGlueAdapterCrawlerMethods:
     def test_delete_crawler(self):
         self.glue_adapter.delete_crawler(RESOURCE_PREFIX, "domain", "dataset")
         self.glue_boto_client.delete_crawler.assert_called_once_with(
-            RESOURCE_PREFIX + "_rapid_crawler/domain/dataset"
+            RESOURCE_PREFIX + "_crawler/domain/dataset"
         )
 
     def test_delete_crawler_fails(self):
@@ -118,7 +118,7 @@ class TestGlueAdapterCrawlerMethods:
         }
         self.glue_adapter.check_crawler_is_ready(RESOURCE_PREFIX, "domain", "dataset")
         self.glue_boto_client.get_crawler.assert_called_once_with(
-            Name=RESOURCE_PREFIX + "_rapid_crawler/domain/dataset"
+            Name=RESOURCE_PREFIX + "_crawler/domain/dataset"
         )
 
     def test_check_crawler_is_not_ready(self):
@@ -132,7 +132,7 @@ class TestGlueAdapterCrawlerMethods:
                 self.glue_adapter.check_crawler_is_ready(RESOURCE_PREFIX, "domain", "dataset")
 
             self.glue_boto_client.get_crawler.assert_called_with(
-                Name=RESOURCE_PREFIX + "_rapid_crawler/domain/dataset"
+                Name=RESOURCE_PREFIX + "_crawler/domain/dataset"
             )
 
 

--- a/test/api/adapter/test_glue_adapter.py
+++ b/test/api/adapter/test_glue_adapter.py
@@ -29,10 +29,10 @@ class TestGlueAdapterCrawlerMethods:
 
     def test_create_crawler(self):
         self.glue_adapter.create_crawler(
-            "domain", "dataset", {"tag1": "value1", "tag2": "value2", "tag3": "value3"}
+            "resource_prefix", "domain", "dataset", {"tag1": "value1", "tag2": "value2", "tag3": "value3"}
         )
         self.glue_boto_client.create_crawler.assert_called_once_with(
-            Name="rapid_crawler/domain/dataset",
+            Name="resource_prefix_rapid_crawler/domain/dataset",
             Role="GLUE_CRAWLER_ROLE",
             DatabaseName="GLUE_CATALOGUE_DB_NAME",
             TablePrefix="domain_",
@@ -59,7 +59,7 @@ class TestGlueAdapterCrawlerMethods:
         )
 
         with pytest.raises(CrawlerCreateFailsError):
-            self.glue_adapter.create_crawler("domain", "dataset", {})
+            self.glue_adapter.create_crawler("resource_prefix", "domain", "dataset", {})
 
     def test_create_crawler_fails(self):
         self.glue_boto_client.create_crawler.side_effect = ClientError(
@@ -68,12 +68,12 @@ class TestGlueAdapterCrawlerMethods:
         )
 
         with pytest.raises(CrawlerCreateFailsError):
-            self.glue_adapter.create_crawler("domain", "dataset", {})
+            self.glue_adapter.create_crawler("resource_prefix", "domain", "dataset", {})
 
     def test_start_crawler(self):
-        self.glue_adapter.start_crawler("domain", "dataset")
+        self.glue_adapter.start_crawler("resource_prefix", "domain", "dataset")
         self.glue_boto_client.start_crawler.assert_called_once_with(
-            Name="rapid_crawler/domain/dataset"
+            Name="resource_prefix_rapid_crawler/domain/dataset"
         )
 
     def test_start_crawler_fails(self):
@@ -83,12 +83,12 @@ class TestGlueAdapterCrawlerMethods:
         )
 
         with pytest.raises(CrawlerStartFailsError):
-            self.glue_adapter.start_crawler("domain", "dataset")
+            self.glue_adapter.start_crawler("resource_prefix", "domain", "dataset")
 
     def test_delete_crawler(self):
-        self.glue_adapter.delete_crawler("domain", "dataset")
+        self.glue_adapter.delete_crawler("resource_prefix", "domain", "dataset")
         self.glue_boto_client.delete_crawler.assert_called_once_with(
-            "rapid_crawler/domain/dataset"
+            "resource_prefix_rapid_crawler/domain/dataset"
         )
 
     def test_delete_crawler_fails(self):
@@ -98,7 +98,7 @@ class TestGlueAdapterCrawlerMethods:
         )
 
         with pytest.raises(CrawlerDeleteFailsError):
-            self.glue_adapter.delete_crawler("domain", "dataset")
+            self.glue_adapter.delete_crawler("resource_prefix", "domain", "dataset")
 
     def test_fails_to_check_if_crawler_is_running(self):
         self.glue_boto_client.get_crawler.side_effect = ClientError(
@@ -107,7 +107,7 @@ class TestGlueAdapterCrawlerMethods:
         )
 
         with pytest.raises(GetCrawlerError):
-            self.glue_adapter.check_crawler_is_ready("domain", "dataset")
+            self.glue_adapter.check_crawler_is_ready("resource_prefix", "domain", "dataset")
 
     def test_check_crawler_is_ready(self):
         self.glue_boto_client.get_crawler.return_value = {
@@ -115,9 +115,9 @@ class TestGlueAdapterCrawlerMethods:
                 "State": "READY",
             }
         }
-        self.glue_adapter.check_crawler_is_ready("domain", "dataset")
+        self.glue_adapter.check_crawler_is_ready("resource_prefix", "domain", "dataset")
         self.glue_boto_client.get_crawler.assert_called_once_with(
-            Name="rapid_crawler/domain/dataset"
+            Name="resource_prefix_rapid_crawler/domain/dataset"
         )
 
     def test_check_crawler_is_not_ready(self):
@@ -128,10 +128,10 @@ class TestGlueAdapterCrawlerMethods:
                 }
             }
             with pytest.raises(CrawlerIsNotReadyError):
-                self.glue_adapter.check_crawler_is_ready("domain", "dataset")
+                self.glue_adapter.check_crawler_is_ready("resource_prefix", "domain", "dataset")
 
             self.glue_boto_client.get_crawler.assert_called_with(
-                Name="rapid_crawler/domain/dataset"
+                Name="resource_prefix_rapid_crawler/domain/dataset"
             )
 
 

--- a/test/api/application/services/test_data_service.py
+++ b/test/api/application/services/test_data_service.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock, patch
 
 import pandas as pd
+from api.common.config.aws import RESOURCE_PREFIX
 import pytest
 
 from api.application.services.data_service import DataService
@@ -228,7 +229,7 @@ class TestUploadDataset:
         )
 
         filename = self.data_service.upload_dataset(
-            "some", "other", "data.csv", file_contents
+            RESOURCE_PREFIX, "some", "other", "data.csv", file_contents
         )
         assert filename == "2022-03-03T12:00:00-data.csv"
 
@@ -288,7 +289,7 @@ class TestUploadDataset:
         )
 
         filename = self.data_service.upload_dataset(
-            "some", "other", "data.csv", file_contents
+            RESOURCE_PREFIX, "some", "other", "data.csv", file_contents
         )
         assert filename == "2022-03-02T12:00:00-data.csv"
 
@@ -343,7 +344,7 @@ class TestUploadDataset:
         mock_partitioner.return_value = partitioned_data
 
         filename = self.data_service.upload_dataset(
-            "some", "other", "data.csv", file_contents
+            RESOURCE_PREFIX, "some", "other", "data.csv", file_contents
         )
         assert filename == "some.csv"
 
@@ -400,7 +401,7 @@ class TestUploadDataset:
         mock_partitioner.return_value = partitioned_data
 
         filename = self.data_service.upload_dataset(
-            "some", "other", "data.csv", file_contents
+            RESOURCE_PREFIX, "some", "other", "data.csv", file_contents
         )
         assert filename == "some.csv"
 
@@ -462,7 +463,7 @@ class TestUploadDataset:
         )
 
         filename = self.data_service.upload_dataset(
-            "some", "other", "data.csv", file_contents
+            RESOURCE_PREFIX, "some", "other", "data.csv", file_contents
         )
         assert filename == "2022-03-03T12:00:00-data.csv"
 
@@ -490,7 +491,7 @@ class TestUploadDataset:
         self.s3_adapter.find_schema.return_value = None
 
         with pytest.raises(SchemaNotFoundError):
-            self.data_service.upload_dataset("some", "other", "data.csv", file_contents)
+            self.data_service.upload_dataset(RESOURCE_PREFIX, "some", "other", "data.csv", file_contents)
 
         self.s3_adapter.find_schema.assert_called_once_with("some", "other")
 
@@ -526,10 +527,10 @@ class TestUploadDataset:
         self.glue_adapter.check_crawler_is_ready.side_effect = GetCrawlerError("msg")
 
         with pytest.raises(GetCrawlerError):
-            self.data_service.upload_dataset("some", "other", "data.csv", file_contents)
+            self.data_service.upload_dataset(RESOURCE_PREFIX, "some", "other", "data.csv", file_contents)
 
         self.glue_adapter.check_crawler_is_ready.assert_called_once_with(
-            "some", "other"
+            RESOURCE_PREFIX, "some", "other"
         )
 
     def test_upload_dataset_fails_when_crawler_is_not_ready(self):
@@ -565,10 +566,10 @@ class TestUploadDataset:
         )
 
         with pytest.raises(CrawlerIsNotReadyError):
-            self.data_service.upload_dataset("some", "other", "data.csv", file_contents)
+            self.data_service.upload_dataset(RESOURCE_PREFIX, "some", "other", "data.csv", file_contents)
 
         self.glue_adapter.check_crawler_is_ready.assert_called_once_with(
-            "some", "other"
+            RESOURCE_PREFIX, "some", "other"
         )
 
     def test_upload_dataset_starts_crawler(self):
@@ -599,9 +600,9 @@ class TestUploadDataset:
             ],
         )
 
-        self.data_service.upload_dataset("some", "other", "data.csv", file_contents)
+        self.data_service.upload_dataset(RESOURCE_PREFIX, "some", "other", "data.csv", file_contents)
 
-        self.glue_adapter.start_crawler.assert_called_once_with("some", "other")
+        self.glue_adapter.start_crawler.assert_called_once_with(RESOURCE_PREFIX, "some", "other")
 
     def test_upload_dataset_fails_to_start_crawler(self):
         file_contents = set_encoded_content(
@@ -636,7 +637,7 @@ class TestUploadDataset:
         )
 
         with pytest.raises(CrawlerStartFailsError):
-            self.data_service.upload_dataset("some", "other", "data.csv", file_contents)
+            self.data_service.upload_dataset(RESOURCE_PREFIX, "some", "other", "data.csv", file_contents)
 
     # Persist raw copy of data -------------------------------
     def test_upload_dataset_persists_raw_copy_of_data(self):
@@ -670,7 +671,7 @@ class TestUploadDataset:
             return_value=("2022-03-03T12:00:00-data.csv")
         )
 
-        self.data_service.upload_dataset("some", "other", "data.csv", file_contents)
+        self.data_service.upload_dataset(RESOURCE_PREFIX, "some", "other", "data.csv", file_contents)
 
         self.s3_adapter.upload_raw_data.assert_called_once_with(
             "some", "other", "2022-03-03T12:00:00-data.csv", file_contents

--- a/test/api/controller/test_datasets.py
+++ b/test/api/controller/test_datasets.py
@@ -19,6 +19,7 @@ from api.domain.dataset_filter_query import DatasetFilterQuery
 from api.domain.schema import Schema, SchemaMetadata, Owner, Column
 from api.domain.sql_query import SQLQuery
 from api.domain.storage_metadata import EnrichedDatasetMetaData
+from api.common.config.aws import RESOURCE_PREFIX
 
 from test.api.controller.controller_test_utils import BaseClientTest
 
@@ -39,7 +40,7 @@ class TestDataUpload(BaseClientTest):
         )
 
         mock_upload_dataset.assert_called_once_with(
-            "domain", "dataset", file_name, file_content
+            RESOURCE_PREFIX, "domain", "dataset", file_name, file_content
         )
 
         assert response.status_code == 201
@@ -61,7 +62,7 @@ class TestDataUpload(BaseClientTest):
         )
 
         mock_upload_dataset.assert_called_once_with(
-            "domain", "dataset", file_name, file_content
+            RESOURCE_PREFIX, "domain", "dataset", file_name, file_content
         )
 
         assert response.status_code == 400
@@ -85,7 +86,7 @@ class TestDataUpload(BaseClientTest):
         )
 
         mock_upload_dataset.assert_called_once_with(
-            "domain", "dataset", file_name, file_content
+            RESOURCE_PREFIX, "domain", "dataset", file_name, file_content
         )
 
         assert response.status_code == 202
@@ -138,7 +139,7 @@ class TestDataUpload(BaseClientTest):
         )
 
         mock_upload_dataset.assert_called_once_with(
-            "domain", "dataset", file_name, file_content
+            RESOURCE_PREFIX, "domain", "dataset", file_name, file_content
         )
 
         assert response.status_code == 429
@@ -160,7 +161,7 @@ class TestDataUpload(BaseClientTest):
         )
 
         mock_upload_dataset.assert_called_once_with(
-            "domain", "dataset", file_name, file_content
+            RESOURCE_PREFIX, "domain", "dataset", file_name, file_content
         )
 
         assert response.status_code == 500

--- a/test/api/controller/test_datasets.py
+++ b/test/api/controller/test_datasets.py
@@ -516,7 +516,7 @@ class TestDeleteFiles(BaseClientTest):
         )
 
         mock_delete_dataset_file.assert_called_once_with(
-            "mydomain", "mydataset", "2022-01-01T00:00:00-file.csv"
+            RESOURCE_PREFIX, "mydomain", "mydataset", "2022-01-01T00:00:00-file.csv"
         )
 
         assert response.status_code == 204
@@ -535,7 +535,7 @@ class TestDeleteFiles(BaseClientTest):
         )
 
         mock_delete_dataset_file.assert_called_once_with(
-            "mydomain", "mydataset", "2022-01-01T00:00:00-file.csv"
+            RESOURCE_PREFIX, "mydomain", "mydataset", "2022-01-01T00:00:00-file.csv"
         )
 
         assert response.status_code == 429
@@ -557,7 +557,7 @@ class TestDeleteFiles(BaseClientTest):
         )
 
         mock_delete_dataset_file.assert_called_once_with(
-            "mydomain", "mydataset", "2022-01-01T00:00:00-file.csv"
+            RESOURCE_PREFIX, "mydomain", "mydataset", "2022-01-01T00:00:00-file.csv"
         )
 
         assert response.status_code == 202
@@ -573,7 +573,7 @@ class TestDeleteFiles(BaseClientTest):
         )
 
         mock_delete_dataset_file.assert_called_once_with(
-            "mydomain", "mydataset", "2022-01-01T00:00:00-file.csv"
+            RESOURCE_PREFIX, "mydomain", "mydataset", "2022-01-01T00:00:00-file.csv"
         )
 
         assert response.status_code == 400

--- a/test/api/controller/test_schema.py
+++ b/test/api/controller/test_schema.py
@@ -15,6 +15,7 @@ from api.common.custom_exceptions import (
 )
 from api.domain.schema import Schema, SchemaMetadata, Column, Owner
 from test.api.controller.controller_test_utils import BaseClientTest
+from api.common.config.aws import RESOURCE_PREFIX
 
 
 class TestSchemaUpload(BaseClientTest):
@@ -35,6 +36,7 @@ class TestSchemaUpload(BaseClientTest):
         mock_upload_schema.assert_called_once_with(expected_schema)
         mock_create_user_groups.assert_called_once_with("some", "thing")
         mock_create_crawler.assert_called_once_with(
+            RESOURCE_PREFIX,
             "some",
             "thing",
             {


### PR DESCRIPTION
Add resource_prefix to glue crawler name to make it clearer what instance of rapid the crawler is for and reduce namespace conflicts.