### PR TITLE
Limit resourcetaggingapi to rAPId only Glue DB

### DIFF
--- a/api/adapter/aws_resource_adapter.py
+++ b/api/adapter/aws_resource_adapter.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 import boto3
 from botocore.exceptions import ClientError
 
-from api.common.config.aws import AWS_REGION, RESOURCE_PREFIX
+from api.common.config.aws import AWS_REGION, RESOURCE_PREFIX, GLUE_CATALOGUE_DB_NAME
 from api.common.config.constants import FIRST_SCHEMA_VERSION_NUMBER
 from api.common.custom_exceptions import AWSServiceError, UserError
 from api.common.logger import AppLogger
@@ -69,11 +69,13 @@ class AWSResourceAdapter:
             )
 
     def _get_resources(self, resource_types: List[str], tag_filters: List[Dict]):
-        AppLogger.info(f"Getting AWS resources with tags {tag_filters}")
+        default_tag_filters = [{"Key": "db_name", "Values": [GLUE_CATALOGUE_DB_NAME]}]
+        filters = default_tag_filters + tag_filters
+        AppLogger.info(f"Getting AWS resources with tags {filters}")
         paginator = self.__resource_client.get_paginator("get_resources")
         page_iterator = paginator.paginate(
             ResourceTypeFilters=resource_types,
-            TagFilters=tag_filters,
+            TagFilters=filters,
         )
         return (
             item for page in page_iterator for item in page["ResourceTagMappingList"]

--- a/api/adapter/aws_resource_adapter.py
+++ b/api/adapter/aws_resource_adapter.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 import boto3
 from botocore.exceptions import ClientError
 
-from api.common.config.aws import AWS_REGION, RESOURCE_PREFIX, GLUE_CATALOGUE_DB_NAME
+from api.common.config.aws import AWS_REGION, RESOURCE_PREFIX
 from api.common.config.constants import FIRST_SCHEMA_VERSION_NUMBER
 from api.common.custom_exceptions import AWSServiceError, UserError
 from api.common.logger import AppLogger
@@ -69,7 +69,7 @@ class AWSResourceAdapter:
             )
 
     def _get_resources(self, resource_types: List[str], tag_filters: List[Dict]):
-        default_tag_filters = [{"Key": "db_name", "Values": [GLUE_CATALOGUE_DB_NAME]}]
+        default_tag_filters = [{"Key": "resource_prefix", "Values": [RESOURCE_PREFIX]}]
         filters = default_tag_filters + tag_filters
         AppLogger.info(f"Getting AWS resources with tags {filters}")
         paginator = self.__resource_client.get_paginator("get_resources")

--- a/api/adapter/glue_adapter.py
+++ b/api/adapter/glue_adapter.py
@@ -46,7 +46,7 @@ class GlueAdapter:
 
     def create_crawler(self, dataset: DatasetMetadata, tags: Dict[str, str]):
         try:
-            default_tags = {"db_name": GLUE_CATALOGUE_DB_NAME}
+            default_tags = {"resource_prefix": RESOURCE_PREFIX}
             self.glue_client.create_crawler(
                 Name=dataset.generate_crawler_name(),
                 Role=self.glue_crawler_role,

--- a/api/adapter/glue_adapter.py
+++ b/api/adapter/glue_adapter.py
@@ -46,6 +46,7 @@ class GlueAdapter:
 
     def create_crawler(self, dataset: DatasetMetadata, tags: Dict[str, str]):
         try:
+            default_tags = {"db_name": GLUE_CATALOGUE_DB_NAME}
             self.glue_client.create_crawler(
                 Name=dataset.generate_crawler_name(),
                 Role=self.glue_crawler_role,
@@ -69,7 +70,7 @@ class GlueAdapter:
                         },
                     }
                 ),
-                Tags=tags,
+                Tags={**default_tags, **tags},
             )
         except ClientError as error:
             self._handle_crawler_create_error(error)

--- a/api/domain/dataset_filters.py
+++ b/api/domain/dataset_filters.py
@@ -4,7 +4,6 @@ from pydantic.main import BaseModel
 
 from api.common.custom_exceptions import UserError
 from api.common.config.auth import Layer
-from api.common.config.aws import GLUE_CATALOGUE_DB_NAME
 
 
 class DatasetFilters(BaseModel):
@@ -29,15 +28,11 @@ class DatasetFilters(BaseModel):
         ]
 
     def _tag_filters(self) -> List[Dict]:
-        default_tags_dict_list = {"Key": "db_name", "Values": [GLUE_CATALOGUE_DB_NAME]}
-
         key_value_tags_dict_list = self._build_key_value_tags()
 
         key_only_tags_dict_list = self._build_key_only_tags()
 
-        return (
-            default_tags_dict_list + key_value_tags_dict_list + key_only_tags_dict_list
-        )
+        return key_value_tags_dict_list + key_only_tags_dict_list
 
     def _build_key_only_tags(self):
         return [{"Key": key, "Values": []} for key in self.key_only_tags]

--- a/api/domain/dataset_filters.py
+++ b/api/domain/dataset_filters.py
@@ -4,6 +4,7 @@ from pydantic.main import BaseModel
 
 from api.common.custom_exceptions import UserError
 from api.common.config.auth import Layer
+from api.common.config.aws import GLUE_CATALOGUE_DB_NAME
 
 
 class DatasetFilters(BaseModel):
@@ -28,12 +29,15 @@ class DatasetFilters(BaseModel):
         ]
 
     def _tag_filters(self) -> List[Dict]:
+        default_tags_dict_list = {"Key": "db_name", "Values": [GLUE_CATALOGUE_DB_NAME]}
 
         key_value_tags_dict_list = self._build_key_value_tags()
 
         key_only_tags_dict_list = self._build_key_only_tags()
 
-        return key_value_tags_dict_list + key_only_tags_dict_list
+        return (
+            default_tags_dict_list + key_value_tags_dict_list + key_only_tags_dict_list
+        )
 
     def _build_key_only_tags(self):
         return [{"Key": key, "Values": []} for key in self.key_only_tags]

--- a/migrations/scripts/v7_layer_migration.py
+++ b/migrations/scripts/v7_layer_migration.py
@@ -212,9 +212,7 @@ def migrate_crawlers(layer: str, glue_client, resource_client):
 
 
 def format_tags_acceptably_for_crawler_creation(tags: List[dict]) -> dict:
-    new_default_tags = {"db_name": GLUE_CATALOGUE_DB_NAME}
-    existing_formatted_tags = {tag["Key"]: tag["Value"] for tag in tags}
-    return {**new_default_tags, **existing_formatted_tags}
+    return {tag["Key"]: tag["Value"] for tag in tags}
 
 
 def create_new_crawler(layer: str, crawler_info: dict, glue_client) -> str:

--- a/migrations/scripts/v7_layer_migration.py
+++ b/migrations/scripts/v7_layer_migration.py
@@ -254,6 +254,7 @@ def create_new_crawler(layer: str, crawler_info: dict, glue_client) -> str:
         crawler_info["Tags"]
     )
     domain = new_crawler["Name"].split("/")[1]
+    new_crawler["Tags"]["resource_prefix"] = RESOURCE_PREFIX
     new_crawler["Tags"]["domain"] = domain
     new_crawler["Tags"]["layer"] = layer
     glue_client.create_crawler(**new_crawler)

--- a/migrations/scripts/v7_layer_migration.py
+++ b/migrations/scripts/v7_layer_migration.py
@@ -30,6 +30,7 @@ SCHEMAS_PATH = "data/schemas"
 RAW_DATA_PATH = "raw_data"
 GLUE_DB = f"{RESOURCE_PREFIX}_catalogue_db"
 DYNAMODB_PERMISSIONS_TABLE = f"{RESOURCE_PREFIX}_users_permissions"
+GLUE_CATALOGUE_DB_NAME = RESOURCE_PREFIX + "_catalogue_db"
 
 
 def main(
@@ -211,7 +212,9 @@ def migrate_crawlers(layer: str, glue_client, resource_client):
 
 
 def format_tags_acceptably_for_crawler_creation(tags: List[dict]) -> dict:
-    return {tag["Key"]: tag["Value"] for tag in tags}
+    new_default_tags = {"db_name": GLUE_CATALOGUE_DB_NAME}
+    existing_formatted_tags = {tag["Key"]: tag["Value"] for tag in tags}
+    return {**new_default_tags, **existing_formatted_tags}
 
 
 def create_new_crawler(layer: str, crawler_info: dict, glue_client) -> str:

--- a/test/api/adapter/test_aws_resource_adapter.py
+++ b/test/api/adapter/test_aws_resource_adapter.py
@@ -5,7 +5,7 @@ from botocore.exceptions import ClientError
 
 from api.adapter.aws_resource_adapter import AWSResourceAdapter
 from api.adapter.s3_adapter import S3Adapter
-from api.common.config.aws import AWS_REGION, RESOURCE_PREFIX
+from api.common.config.aws import AWS_REGION, RESOURCE_PREFIX, GLUE_CATALOGUE_DB_NAME
 from api.common.custom_exceptions import UserError, AWSServiceError
 from api.domain.dataset_filters import DatasetFilters
 from api.domain.dataset_metadata import DatasetMetadata
@@ -214,7 +214,8 @@ class TestAWSResourceAdapterClientMethods:
 
         self.resource_boto_client.get_paginator.assert_called_once_with("get_resources")
         self.resource_boto_client.get_paginator.return_value.paginate.assert_called_once_with(
-            ResourceTypeFilters=["glue:crawler"], TagFilters=[]
+            ResourceTypeFilters=["glue:crawler"],
+            TagFilters=[{"Key": "db_name", "Values": [GLUE_CATALOGUE_DB_NAME]}],
         )
 
         assert actual_metadatas == expected_metadatas
@@ -230,7 +231,8 @@ class TestAWSResourceAdapterClientMethods:
 
         self.resource_boto_client.get_paginator.assert_called_once_with("get_resources")
         self.resource_boto_client.get_paginator.return_value.paginate.assert_called_once_with(
-            ResourceTypeFilters=["glue:crawler"], TagFilters=[]
+            ResourceTypeFilters=["glue:crawler"],
+            TagFilters=[{"Key": "db_name", "Values": [GLUE_CATALOGUE_DB_NAME]}],
         )
 
         assert len(actual_metadatas) == 0
@@ -251,6 +253,7 @@ class TestAWSResourceAdapterClientMethods:
         self.resource_boto_client.get_paginator.return_value.paginate.assert_called_once_with(
             ResourceTypeFilters=["glue:crawler"],
             TagFilters=[
+                {"Key": "db_name", "Values": [GLUE_CATALOGUE_DB_NAME]},
                 {"Key": "tag1", "Values": ["value1"]},
                 {"Key": "tag2", "Values": []},
             ],

--- a/test/api/adapter/test_aws_resource_adapter.py
+++ b/test/api/adapter/test_aws_resource_adapter.py
@@ -5,7 +5,7 @@ from botocore.exceptions import ClientError
 
 from api.adapter.aws_resource_adapter import AWSResourceAdapter
 from api.adapter.s3_adapter import S3Adapter
-from api.common.config.aws import AWS_REGION, RESOURCE_PREFIX, GLUE_CATALOGUE_DB_NAME
+from api.common.config.aws import AWS_REGION, RESOURCE_PREFIX
 from api.common.custom_exceptions import UserError, AWSServiceError
 from api.domain.dataset_filters import DatasetFilters
 from api.domain.dataset_metadata import DatasetMetadata
@@ -215,7 +215,7 @@ class TestAWSResourceAdapterClientMethods:
         self.resource_boto_client.get_paginator.assert_called_once_with("get_resources")
         self.resource_boto_client.get_paginator.return_value.paginate.assert_called_once_with(
             ResourceTypeFilters=["glue:crawler"],
-            TagFilters=[{"Key": "db_name", "Values": [GLUE_CATALOGUE_DB_NAME]}],
+            TagFilters=[{"Key": "resource_prefix", "Values": [RESOURCE_PREFIX]}],
         )
 
         assert actual_metadatas == expected_metadatas
@@ -232,7 +232,7 @@ class TestAWSResourceAdapterClientMethods:
         self.resource_boto_client.get_paginator.assert_called_once_with("get_resources")
         self.resource_boto_client.get_paginator.return_value.paginate.assert_called_once_with(
             ResourceTypeFilters=["glue:crawler"],
-            TagFilters=[{"Key": "db_name", "Values": [GLUE_CATALOGUE_DB_NAME]}],
+            TagFilters=[{"Key": "resource_prefix", "Values": [RESOURCE_PREFIX]}],
         )
 
         assert len(actual_metadatas) == 0
@@ -253,7 +253,7 @@ class TestAWSResourceAdapterClientMethods:
         self.resource_boto_client.get_paginator.return_value.paginate.assert_called_once_with(
             ResourceTypeFilters=["glue:crawler"],
             TagFilters=[
-                {"Key": "db_name", "Values": [GLUE_CATALOGUE_DB_NAME]},
+                {"Key": "resource_prefix", "Values": [RESOURCE_PREFIX]},
                 {"Key": "tag1", "Values": ["value1"]},
                 {"Key": "tag2", "Values": []},
             ],

--- a/test/api/adapter/test_glue_adapter.py
+++ b/test/api/adapter/test_glue_adapter.py
@@ -62,7 +62,7 @@ class TestGlueAdapterCrawlerMethods:
             SchemaChangePolicy={"DeleteBehavior": "DELETE_FROM_DATABASE"},
             Configuration='{"Version": 1.0, "Grouping": {"TableLevelConfiguration": 6, "TableGroupingPolicy": "CombineCompatibleSchemas"}}',
             Tags={
-                "db_name": GLUE_CATALOGUE_DB_NAME,
+                "resource_prefix": RESOURCE_PREFIX,
                 "tag1": "value1",
                 "tag2": "value2",
                 "tag3": "value3",

--- a/test/api/adapter/test_glue_adapter.py
+++ b/test/api/adapter/test_glue_adapter.py
@@ -62,6 +62,7 @@ class TestGlueAdapterCrawlerMethods:
             SchemaChangePolicy={"DeleteBehavior": "DELETE_FROM_DATABASE"},
             Configuration='{"Version": 1.0, "Grouping": {"TableLevelConfiguration": 6, "TableGroupingPolicy": "CombineCompatibleSchemas"}}',
             Tags={
+                "db_name": GLUE_CATALOGUE_DB_NAME,
                 "tag1": "value1",
                 "tag2": "value2",
                 "tag3": "value3",


### PR DESCRIPTION
## Changes

- Introduces new `db_name` tag onto every crawler
- All `resourcetaggingapi`calls now filter on the `db_name` by default